### PR TITLE
Add localization with language selector

### DIFF
--- a/KMN_Tontine.Blazor.UI/Components/Layout/MainLayout.razor
+++ b/KMN_Tontine.Blazor.UI/Components/Layout/MainLayout.razor
@@ -1,5 +1,6 @@
 @inherits LayoutComponentBase
 @using Microsoft.AspNetCore.Components.Authorization
+@inject LanguageService LangService
 
 <PageTitle>KMN Tontine</PageTitle>
 
@@ -7,7 +8,10 @@
     <AuthorizeView>
         <Authorized>
             <div class="d-flex" style="height: 100vh; overflow: hidden;">
-                <!-- Sidebar fixée -->
+
+        var culture = await LangService.GetCultureAsync();
+        await LangService.SetCultureAsync(culture);
+}
                 <div class="bg-primary text-white p-3 flex-shrink-0" style="width: 250px; height: auto; position: fixed; left: 0; top: 0; overflow-y: auto;">
                     <MainNav />
                 </div>

--- a/KMN_Tontine.Blazor.UI/Components/Layout/MainNav.razor
+++ b/KMN_Tontine.Blazor.UI/Components/Layout/MainNav.razor
@@ -5,7 +5,8 @@
 @inject NavigationManager Navigation
 @inject IAuthService AuthenticationService
 @inject CurrentUserService CurrentUserServ
-@* @inject IStringLocalizer<Resource> localizer *@
+@inject IStringLocalizer<Resource> localizer
+@inject LanguageService LangService
 
 <div class="h-screen flex overflow-hidden bg-gray-100" style="height: auto">
     <!-- Sidebar Desktop -->
@@ -21,9 +22,9 @@
     </button>
 
     <!-- Sélecteur de langue -->
-@*     <div class="fixed top-4 right-4 z-50">
+    <div class="fixed top-4 right-4 z-50">
         <LanguageSelector />
-    </div> *@
+    </div>
 </div>
 
 @code {
@@ -33,24 +34,27 @@
 
     protected override async Task OnInitializedAsync()
     {
+        var culture = await LangService.GetCultureAsync();
+        await LangService.SetCultureAsync(culture);
+
         await CurrentUserServ.LoadUserInfoAsync();
 
         NavigationItems = new()
         {
-            new NavItem("Accueil", "/dashboard", "fas fa-home", "Tous")
+            new NavItem(localizer["Home"], "/dashboard", "fas fa-home", "Tous")
         };
 
         if (CurrentUserServ.IsAdmin)
         {
             NavigationItems.AddRange(new[]
             {
-                new NavItem("Membres", "/admin/members", "fas fa-users", "Admin"),
-                new NavItem("Membres en attente", "/admin/pending-members", "fas fa-user-clock", "Admin"),
-                new NavItem("Comptes", "/admin/allaccounts", "fas fa-university", "Admin"),
-                new NavItem("Transactions", "/admin/transactions", "fas fa-exchange-alt", "Admin"),
-                new NavItem("Paiements / Promesses", "/admin/payment-promises", "fas fa-money-check-alt", "Admin"),
-                new NavItem("Rapports", "/admin/reports", "fas fa-chart-bar", "Admin"),
-                new NavItem("Paramètres", "/admin/settings", "fas fa-cog", "Admin")
+                new NavItem(localizer["Members"], "/admin/members", "fas fa-users", "Admin"),
+                new NavItem(localizer["PendingMembers"], "/admin/pending-members", "fas fa-user-clock", "Admin"),
+                new NavItem(localizer["Accounts"], "/admin/allaccounts", "fas fa-university", "Admin"),
+                new NavItem(localizer["Transactions"], "/admin/transactions", "fas fa-exchange-alt", "Admin"),
+                new NavItem(localizer["Payments"], "/admin/payment-promises", "fas fa-money-check-alt", "Admin"),
+                new NavItem(localizer["Reports"], "/admin/reports", "fas fa-chart-bar", "Admin"),
+                new NavItem(localizer["Settings"], "/admin/settings", "fas fa-cog", "Admin")
             });
         }
 
@@ -58,10 +62,10 @@
         {
             NavigationItems.AddRange(new[]
             {
-                new NavItem("Mes comptes", "/myaccounts", "fas fa-wallet", "Member"),
-                new NavItem("Mes transactions", "/transactions", "fas fa-history", "Member"),
-                new NavItem("Paiements / Promesses", "/payments", "fas fa-money-check-alt", "Member"),
-                new NavItem("Mon profil", "/profile", "fas fa-user-cog", "Member")
+                new NavItem(localizer["MyAccounts"], "/myaccounts", "fas fa-wallet", "Member"),
+                new NavItem(localizer["MyTransactions"], "/transactions", "fas fa-history", "Member"),
+                new NavItem(localizer["Payments"], "/payments", "fas fa-money-check-alt", "Member"),
+                new NavItem(localizer["MyProfile"], "/profile", "fas fa-user-cog", "Member")
             });
         }
     }

--- a/KMN_Tontine.Blazor.UI/Components/Shared/LanguageSelector.razor
+++ b/KMN_Tontine.Blazor.UI/Components/Shared/LanguageSelector.razor
@@ -1,0 +1,24 @@
+@inject LanguageService LangService
+@code {
+    private string currentCulture = "en-US";
+
+    protected override async Task OnInitializedAsync()
+    {
+        currentCulture = await LangService.GetCultureAsync();
+    }
+
+    private async Task OnChange(ChangeEventArgs e)
+    {
+        if (e.Value is string value)
+        {
+            currentCulture = value;
+            await LangService.SetCultureAsync(value);
+            StateHasChanged();
+        }
+    }
+}
+
+<select @onchange="OnChange" value="@currentCulture" class="form-select">
+    <option value="en-US">English</option>
+    <option value="fr-FR">Français</option>
+</select>

--- a/KMN_Tontine.Blazor.UI/Pages/_Host.cshtml
+++ b/KMN_Tontine.Blazor.UI/Pages/_Host.cshtml
@@ -6,6 +6,14 @@
     Layout = "_Layout";
 }
 
+<script>
+    (function() {
+        var culture = localStorage['culture'];
+        if (culture) {
+            document.cookie = '.AspNetCore.Culture=c=' + culture + '|uic=' + culture + '; path=/';
+        }
+    })();
+</script>
 <component type="typeof(App)" render-mode="Server" />
 <head>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">

--- a/KMN_Tontine.Blazor.UI/Pages/_Layout.cshtml
+++ b/KMN_Tontine.Blazor.UI/Pages/_Layout.cshtml
@@ -3,7 +3,8 @@
 @addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
 
 <!DOCTYPE html>
-<html lang="fr">
+@using System.Globalization
+<html lang="@CultureInfo.CurrentUICulture.Name">
 <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
@@ -22,6 +23,7 @@
         <a class="dismiss">🗙</a>
     </div>
 
+    <script src="js/culture.js"></script>
     <script src="_framework/blazor.server.js"></script>
     @RenderSection("Scripts", required: false)
 </body>

--- a/KMN_Tontine.Blazor.UI/Program.cs
+++ b/KMN_Tontine.Blazor.UI/Program.cs
@@ -1,11 +1,14 @@
-﻿using Blazored.LocalStorage;
+using Blazored.LocalStorage;
 
 using KMN_Tontine.Blazor.UI.Helpers;
 using KMN_Tontine.Blazor.UI.Services;
 using KMN_Tontine.Blazor.UI.Services.Authentication;
 using KMN_Tontine.Blazor.UI.Services.Base;
 
+using Microsoft.AspNetCore.Localization;
+using Microsoft.Extensions.Options;
 using Microsoft.AspNetCore.Components.Authorization;
+using System.Globalization;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -37,6 +40,15 @@ builder.Services.AddScoped<AuthenticationStateProvider>(p =>
 builder.Services.AddScoped<ICompteService, CompteService>();
 
 builder.Services.AddScoped<CurrentUserService>();
+builder.Services.AddScoped<LanguageService>();
+builder.Services.AddLocalization(options => options.ResourcesPath = "Locales");
+var supportedCultures = new[] { "en-US", "fr-FR" };
+builder.Services.Configure<RequestLocalizationOptions>(options =>
+{
+    options.DefaultRequestCulture = new RequestCulture("en-US");
+    options.SupportedCultures = supportedCultures.Select(c => new CultureInfo(c)).ToList();
+    options.SupportedUICultures = options.SupportedCultures;
+});
 
 builder.Services.AddSingleton<CurrencyFormatter>();
 
@@ -62,6 +74,8 @@ else
 
 app.UseStaticFiles();
 app.UseRouting();
+var locOptions = app.Services.GetRequiredService<IOptions<RequestLocalizationOptions>>().Value;
+app.UseRequestLocalization(locOptions);
 
 app.UseAuthentication();
 app.UseAuthorization();

--- a/KMN_Tontine.Blazor.UI/Services/LanguageService.cs
+++ b/KMN_Tontine.Blazor.UI/Services/LanguageService.cs
@@ -1,0 +1,33 @@
+using System.Globalization;
+using Blazored.LocalStorage;
+
+namespace KMN_Tontine.Blazor.UI.Services
+{
+    public class LanguageService
+    {
+        private readonly ILocalStorageService _localStorage;
+        private const string CultureKey = "culture";
+
+        public event Action? OnChange;
+
+        public LanguageService(ILocalStorageService localStorage)
+        {
+            _localStorage = localStorage;
+        }
+
+        public async Task SetCultureAsync(string culture)
+        {
+            var ci = new CultureInfo(culture);
+            CultureInfo.DefaultThreadCurrentCulture = ci;
+            CultureInfo.DefaultThreadCurrentUICulture = ci;
+            await _localStorage.SetItemAsync(CultureKey, culture);
+            OnChange?.Invoke();
+        }
+
+        public async Task<string> GetCultureAsync()
+        {
+            var culture = await _localStorage.GetItemAsync<string>(CultureKey);
+            return string.IsNullOrWhiteSpace(culture) ? "en-US" : culture;
+        }
+    }
+}

--- a/KMN_Tontine.Blazor.UI/wwwroot/js/culture.js
+++ b/KMN_Tontine.Blazor.UI/wwwroot/js/culture.js
@@ -1,0 +1,8 @@
+window.blazorCulture = {
+    get: function () {
+        return localStorage['culture'];
+    },
+    set: function (value) {
+        localStorage['culture'] = value;
+    }
+};


### PR DESCRIPTION
## Summary
- enable localization and register LanguageService
- implement request localization middleware
- add LanguageSelector component and culture utilities
- localize navigation labels
- persist culture preference in local storage

## Testing
- `dotnet build KMN_Tontine.sln -c Release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853116a64ac8329b66e8532c359090d